### PR TITLE
Fixed a bug with typed relationship url.

### DIFF
--- a/src/Database/Neo4j/Internal.hs
+++ b/src/Database/Neo4j/Internal.hs
@@ -27,7 +27,7 @@ escape = escapeURIString isUnreserved
 appendToPath uri appendage = uri { uriPath = uriPath uri ++ appendage' }
     where appendage' = case appendage of
                         [] -> []
-                        ('/':_) -> escape appendage
+                        ('/':rest) -> '/':escape rest
                         _ -> '/':(escape appendage)
 
 buildRequestWithContent method uri content =

--- a/src/Database/Neo4j/Relationship.hs
+++ b/src/Database/Neo4j/Relationship.hs
@@ -98,12 +98,11 @@ mkRelationshipFromAttributes client (self, start, end, name, props) = do
 -- | Get all the relationships of a given type for a node.
 getRelationships :: Client -> RelationshipRetrievalType -> Node -> IO (Either String [Relationship])
 getRelationships client rrType (Node nodeURI _) = do
-    let uri = nodeURI `appendToPath` "relationships" `appendToPath`
-            case rrType of
-                RetrieveAll ->  "all"
-                RetrieveIncoming -> "in"
-                RetrieveOutgoing -> "out"
-                RetrieveTyped relType -> "all/" ++ relType
+    let uri = case rrType of
+                RetrieveAll -> nodeURI `appendToPath` "relationships" `appendToPath` "all"
+                RetrieveIncoming -> nodeURI `appendToPath` "relationships" `appendToPath` "in"
+                RetrieveOutgoing -> nodeURI `appendToPath` "relationships" `appendToPath` "out"
+                RetrieveTyped relType -> nodeURI `appendToPath` "relationships" `appendToPath` "all" `appendToPath` relType
     result <- simpleHTTP $ mkRequest GET uri
     let relationshipResult = case result of
             Right response -> case rspCode response of


### PR DESCRIPTION
In the url for getting all relationships of a node with a certain labal (type) a slash was escaped so that the request failed with 404.